### PR TITLE
fix: sde download

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docker/common/sde.tar.xz filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2006-2026 Knut Reinert & Freie Universität Berlin
+# SPDX-FileCopyrightText: 2016-2026 Knut Reinert & MPI für molekulare Genetik
+# SPDX-License-Identifier: CC-BY-4.0
 docker/common/sde.tar.xz filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          lfs: true
 
       - name: Build base image
         working-directory: ./docker

--- a/LICENSES/LicenseRef-intel-simplified-software-license.txt
+++ b/LICENSES/LicenseRef-intel-simplified-software-license.txt
@@ -1,0 +1,40 @@
+Intel Simplified Software License (Version October 2022)
+
+PIN: Copyright (C) Intel Corporation
+
+Use and Redistribution.  You may use and redistribute the software, which is provided in binary form only, (the  Software ), without modification, provided the following conditions are met:
+
+* 	Redistributions must reproduce the above copyright notice and these terms of use in the Software and in the documentation and/or other materials provided with the distribution.
+* 	Neither the name of Intel nor the names of its suppliers may be used to endorse or promote products derived from this Software without specific prior written permission.
+* 	No reverse engineering, decompilation, or disassembly of the Software is permitted, nor any modification or alteration of the Software or its operation at any time, including during execution.
+
+No other licenses.  Except as provided in the preceding section, Intel grants no licenses or other rights by implication, estoppel or otherwise to, patent, copyright, trademark, trade name, service mark
+or other intellectual property licenses or rights of Intel.
+
+Third party software.   Third Party Software  means the files (if any) listed in the  third-party-software.txt  or other similarly-named text file that may be included with the Software.
+Third Party Software, even if included with the distribution of the Software, may be governed by separate license terms, including without limitation, third party license terms, open source software notices and terms,
+and/or other Intel software license terms. These separate license terms solely govern Your use of the Third Party Software.
+
+DISCLAIMER.  THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT ARE DISCLAIMED.
+THIS SOFTWARE IS NOT INTENDED FOR USE IN SYSTEMS OR APPLICATIONS WHERE FAILURE OF THE SOFTWARE MAY CAUSE PERSONAL INJURY OR DEATH AND YOU AGREE THAT YOU ARE FULLY RESPONSIBLE FOR ANY CLAIMS, COSTS, DAMAGES, EXPENSES, AND ATTORNEYS  FEES
+ARISING OUT OF ANY SUCH USE, EVEN IF ANY CLAIM ALLEGES THAT INTEL WAS NEGLIGENT REGARDING THE DESIGN OR MANUFACTURE OF THE SOFTWARE.
+
+LIMITATION OF LIABILITY. IN NO EVENT WILL INTEL BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+No support.  Intel may make changes to the Software, at any time without notice, and is not obligated to support, update or provide training for the Software.
+
+Termination. Your right to use the Software is terminated in the event of your breach of this license.
+
+Feedback.  Should you provide Intel with comments, modifications, corrections, enhancements or other input ( Feedback ) related to the Software, Intel will be free to use, disclose, reproduce, license or otherwise distribute or exploit the Feedback in
+its sole discretion without any obligations or restrictions of any kind, including without limitation, intellectual property rights or licensing obligations.
+
+Compliance with laws.  You agree to comply with all relevant laws and regulations governing your use, transfer, import or export (or prohibition thereof) of the Software.
+
+Governing law.  All disputes will be governed by the laws of the United States of America and the State of Delaware without reference to conflict of law principles and subject to the exclusive jurisdiction
+of the state or federal courts sitting in the State of Delaware, and each party agrees that it submits to the personal jurisdiction and venue of those courts and waives any objections.
+THE UNITED NATIONS CONVENTION ON CONTRACTS FOR THE INTERNATIONAL SALE OF GOODS (1980) IS SPECIFICALLY EXCLUDED AND WILL NOT APPLY TO THE SOFTWARE.
+
+
+
+

--- a/docker/common/install_common_packages.sh
+++ b/docker/common/install_common_packages.sh
@@ -15,6 +15,7 @@ apt-get install --yes --no-install-recommends --no-upgrade \
     gcovr \
     gh \
     git \
+    git-lfs \
     gpg \
     gpg-agent \
     libbz2-dev \

--- a/docker/common/install_sde.sh
+++ b/docker/common/install_sde.sh
@@ -7,7 +7,8 @@
 set -Eeuxo pipefail
 
 SDE_EXTRACTION_PATH=$1
-SDE_TARGET_FILE="/tmp/sde.tar.xz"
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+SDE_ARCHIVE="${SCRIPT_DIR}/sde.tar.xz"
 
 # Fail the script if the SDE_EXTRACTION_PATH is empty
 if [[ -z "${SDE_EXTRACTION_PATH}" ]]; then
@@ -15,25 +16,14 @@ if [[ -z "${SDE_EXTRACTION_PATH}" ]]; then
     exit 1
 fi
 
-# Download the SDE tarball
-# Update the following variables if the SDE version changes
-DIR_PATH="913594"
-SDE_VERSION="10.7.0"
-SDE_DATE="2026-02-18"
-
-# Example: https://downloadmirror.intel.com/913594/sde-external-10.7.0-2026-02-18-lin.tar.xz
-FULL_URL="https://downloadmirror.intel.com/${DIR_PATH}/sde-external-${SDE_VERSION}-${SDE_DATE}-lin.tar.xz"
-
-wget --quiet --retry-connrefused --output-document "${SDE_TARGET_FILE}" "${FULL_URL}"
-
 # Create the extraction directory if it doesn't exist
 mkdir -p "${SDE_EXTRACTION_PATH}"
 
 # Extract the tarball file into the extraction directory
-tar xf "${SDE_TARGET_FILE}" -C "${SDE_EXTRACTION_PATH}" --strip-components=1
+tar xf "${SDE_ARCHIVE}" -C "${SDE_EXTRACTION_PATH}" --strip-components=1
 
 # Clean up
-rm "${SDE_TARGET_FILE}"
+rm "${SDE_ARCHIVE}"
 
 # Add the SDE version to the versions file
-echo -e "intel-sde*\t${SDE_VERSION}" | tee -a /manually_installed_packages.version /installed_packages.version > /dev/null
+echo -e "intel-sde*\t$(sde --version | grep -oP 'Version:\s*\K[0-9.]+')" | tee -a /manually_installed_packages.version /installed_packages.version > /dev/null

--- a/docker/common/sde.tar.xz
+++ b/docker/common/sde.tar.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca3d4086de4acb3faedf9f57b541c6936b7d5e19ae2bf763b6ea933573a0a217
+size 44788080

--- a/docker/common/sde.tar.xz.license
+++ b/docker/common/sde.tar.xz.license
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Intel Corporation
+# SPDX-License-Identifier: LicenseRef-intel-simplified-software-license


### PR DESCRIPTION
Download requires a short-lived aws-token that is generated after running a challenge.js. Just use lfs to host it.